### PR TITLE
#17 #18 Compatibility with doctrine naming strategies

### DIFF
--- a/Entity/NotifiableEntity.php
+++ b/Entity/NotifiableEntity.php
@@ -10,7 +10,6 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * Class NotifiableEntity
  * @package Mgilet\NotificationBundle\Entity
  *
- * @ORM\Table(name="notifiable")
  * @ORM\Entity(repositoryClass="Mgilet\NotificationBundle\Entity\Repository\NotifiableRepository")
  * @UniqueEntity(fields={"identifier", "class"})
  */

--- a/Entity/NotifiableNotification.php
+++ b/Entity/NotifiableNotification.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
  * Class NotifiableNotification
  * @package Mgilet\NotificationBundle\Entity
  *
- * @ORM\Table(name="notifiable_notification")
  * @ORM\Entity(repositoryClass="Mgilet\NotificationBundle\Entity\Repository\NotifiableNotificationRepository")
  *
  */

--- a/Entity/Notification.php
+++ b/Entity/Notification.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping as ORM;
  * Class AbstractNotification
  * Notifications defined in your app must implement this class
  *
- * @ORM\Table(name="notification")
  * @ORM\Entity(repositoryClass="Mgilet\NotificationBundle\Entity\Repository\NotificationRepository")
  */
 class Notification


### PR DESCRIPTION
By removing @ORM\Table names you allow Doctrine naming strategies to take place.
http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/namingstrategy.html

Please note: this is a breaking change. The table name for `NotifiableEntity` will change. Doctrine won't be able to rename the table on it's own and will create a new one.

If you use Symfony **default configuration** it will use an underscore naming strategy and you'll have to make a migration like this:

```sql
RENAME TABLE notifiable TO notifiable_entity;
```

You should probably bump the version number when merging this and include a release note for upgrading users.