### PR TITLE
Custom notification added configuration and return of the custom class in manager creation method

### DIFF
--- a/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
+++ b/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Mgilet\NotificationBundle\Entity\NotificationInterface;
 use Symfony\Component\Debug\Exception\ClassNotFoundException;
+use Doctrine\ORM\Version;
 
 class ResolveTargetEntitiesPass implements CompilerPassInterface
 {
@@ -38,5 +39,12 @@ class ResolveTargetEntitiesPass implements CompilerPassInterface
         $def->addMethodCall('addResolveTargetEntity', array(
             NotificationInterface::DEFAULT_NOTIFICATION_ENTITY_CLASS, $notificationEntityClass, array()
         ));
+        // This was added due this problem
+        // https://stackoverflow.com/a/46656413/7070573
+        if (version_compare(Version::VERSION, '2.5.0-DEV') < 0 && !$def->hasTag('doctrine.event_listener')) {
+            $def->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
+        } elseif (!$def->hasTag('doctrine.event_subscriber')) {
+            $def->addTag('doctrine.event_subscriber');
+        }
     }
 }

--- a/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
+++ b/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Project: notification-bundle
+ * User: Leandro Luccerini <leandro.luccerini@gmail.com>
+ * Date: 08/11/18
+ * Time: 14.01
+ */
+
+namespace Mgilet\NotificationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Mgilet\NotificationBundle\Entity\NotificationInterface;
+use Symfony\Component\Debug\Exception\ClassNotFoundException;
+
+class ResolveTargetEntitiesPass implements CompilerPassInterface
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // Gets the notification entity defined by the user (or the default one)
+        $notificationEntityClass = $container->getParameter('mgilet_notification.notification_class');
+        // Skip the resolve_target_entities part if user's has not defined a different entity
+        if (NotificationInterface::DEFAULT_NOTIFICATION_ENTITY_CLASS == $notificationEntityClass) {
+            return;
+        }
+        // Throws exception if the class isn't found
+        if (!class_exists($notificationEntityClass)) {
+            throw new ClassNotFoundException(sprintf("Can't find class %s ", $notificationEntityClass));
+        }
+
+        // Get the doctrine ResolveTargetEntityListener
+        $def = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
+        // Adds the resolve_target_enitity parameter
+        $def->addMethodCall('addResolveTargetEntity', array(
+            NotificationInterface::DEFAULT_NOTIFICATION_ENTITY_CLASS, $notificationEntityClass, array()
+        ));
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,6 +10,7 @@ namespace Mgilet\NotificationBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Mgilet\NotificationBundle\Entity\NotificationInterface;
 
 
 class Configuration implements ConfigurationInterface
@@ -22,7 +23,7 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()
             ->scalarNode('notification_class')
                 ->cannotBeEmpty()
-                ->defaultValue('Mgilet\NotificationBundle\Entity\Notification')
+                ->defaultValue(NotificationInterface::DEFAULT_NOTIFICATION_ENTITY_CLASS)
             ->end()
         ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,17 +17,13 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('mgilet');
+        $rootNode = $treeBuilder->root('mgilet_notification');
 
         $rootNode->children()
-            ->arrayNode('notification')
-                ->children()
-                    ->scalarNode('notification_class')
-                        ->isRequired()
-                        ->cannotBeEmpty()
-                        ->defaultValue('Mgilet\NotificationBundle\Entity\Notification')
-                    ->end()
-                ->end()
+            ->scalarNode('notification_class')
+                ->isRequired()
+                ->cannotBeEmpty()
+                ->defaultValue('Mgilet\NotificationBundle\Entity\Notification')
             ->end()
         ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,7 +21,6 @@ class Configuration implements ConfigurationInterface
 
         $rootNode->children()
             ->scalarNode('notification_class')
-                ->isRequired()
                 ->cannotBeEmpty()
                 ->defaultValue('Mgilet\NotificationBundle\Entity\Notification')
             ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Project: notification-bundle
+ * User: Leandro Luccerini <leandro.luccerini@gmail.com>
+ * Date: 08/11/18
+ * Time: 9.29
+ */
+
+namespace Mgilet\NotificationBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('mgilet');
+
+        $rootNode->children()
+            ->arrayNode('notification')
+                ->children()
+                    ->scalarNode('notification_class')
+                        ->isRequired()
+                        ->cannotBeEmpty()
+                        ->defaultValue('Mgilet\NotificationBundle\Entity\Notification')
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/DependencyInjection/MgiletNotificationExtension.php
+++ b/DependencyInjection/MgiletNotificationExtension.php
@@ -24,6 +24,14 @@ class MgiletNotificationExtension extends Extension
             $container,
             new FileLocator(__DIR__.'/../Resources/config')
         );
+
         $yamlLoader->load('services.yml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        foreach ($config as $key => $value) {
+            $container->setParameter('mgilet.'.$key, $value);
+        }
     }
 }

--- a/DependencyInjection/MgiletNotificationExtension.php
+++ b/DependencyInjection/MgiletNotificationExtension.php
@@ -31,7 +31,7 @@ class MgiletNotificationExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         foreach ($config as $key => $value) {
-            $container->setParameter('mgilet.'.$key, $value);
+            $container->setParameter('mgilet_notification.'.$key, $value);
         }
     }
 }

--- a/Entity/NotificationInterface.php
+++ b/Entity/NotificationInterface.php
@@ -13,6 +13,13 @@ interface NotificationInterface
 {
 
     /**
+     * Defines the default entity used for the notification
+     *
+     * @var string
+     */
+    const DEFAULT_NOTIFICATION_ENTITY_CLASS = 'Mgilet\NotificationBundle\Entity\Notification';
+
+    /**
      * @return int Notification Id
      */
     public function getId();

--- a/Entity/Repository/NotifiableNotificationRepository.php
+++ b/Entity/Repository/NotifiableNotificationRepository.php
@@ -53,7 +53,7 @@ class NotifiableNotificationRepository extends EntityRepository
             ->andWhere('ne.class = :class')
             ->setParameter('identifier', $notifiable_identifier)
             ->setParameter('class', $notifiable_class)
-            ->orderBy('no.id', $order)
+            ->orderBy('no.date', $order)
             ->getQuery()
             ->getResult()
         ;
@@ -107,7 +107,7 @@ class NotifiableNotificationRepository extends EntityRepository
             ->join('nn.notifiableEntity', 'ne')
             ->where('ne.identifier = :identifier')
             ->andWhere('ne.class = :class')
-            ->orderBy('n.id', $order)
+            ->orderBy('n.date', $order)
             ->setParameter('identifier', $identifier)
             ->setParameter('class', $class)
             ;
@@ -126,7 +126,7 @@ class NotifiableNotificationRepository extends EntityRepository
             ->join('nn.notification', 'n')
             ->join('nn.notifiableEntity', 'ne')
             ->where('ne.id = :id')
-            ->orderBy('n.id', $order)
+            ->orderBy('n.date', $order)
             ->setParameter('id', $id)
         ;
     }
@@ -150,7 +150,7 @@ class NotifiableNotificationRepository extends EntityRepository
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    protected function getNotificationCoundQb($notifiable_identifier, $notifiable_class)
+    protected function getNotificationCountQb($notifiable_identifier, $notifiable_class)
     {
         return $this->createQueryBuilder('nn')
             ->select('COUNT(nn.id)')
@@ -180,7 +180,7 @@ class NotifiableNotificationRepository extends EntityRepository
      */
     public function getNotificationCount($notifiable_identifier, $notifiable_class, $seen = null)
     {
-        $qb = $this->getNotificationCoundQb($notifiable_identifier, $notifiable_class);
+        $qb = $this->getNotificationCountQb($notifiable_identifier, $notifiable_class);
 
         if ($seen !== null) {
             $whereSeen = $seen ? 1 : 0;

--- a/Manager/NotificationManager.php
+++ b/Manager/NotificationManager.php
@@ -598,15 +598,15 @@ class NotificationManager
 
     /**
      * @param NotificationInterface $notification
-     * @param string       $subject
+     * @param string       $message
      * @param bool         $flush
      *
      * @return NotificationInterface
      * @throws \Doctrine\ORM\OptimisticLockException
      */
-    public function setMessage(NotificationInterface $notification, $subject, $flush = false)
+    public function setMessage(NotificationInterface $notification, $message, $flush = false)
     {
-        $notification->setSubject($subject);
+        $notification->setMessage($message);
         $this->flush($flush);
 
         $event = new NotificationEvent($notification);

--- a/Manager/NotificationManager.php
+++ b/Manager/NotificationManager.php
@@ -330,7 +330,7 @@ class NotificationManager
      */
     public function createNotification($subject, $message = null, $link = null)
     {
-        $notificationClass = $container->getParameter('mgilet_notification.notification_class');
+        $notificationClass = $this->container->getParameter('mgilet_notification.notification_class');
         $notification = new $notificationClass();
         $notification
             ->setSubject($subject)

--- a/Manager/NotificationManager.php
+++ b/Manager/NotificationManager.php
@@ -330,7 +330,8 @@ class NotificationManager
      */
     public function createNotification($subject, $message = null, $link = null)
     {
-        $notification = new Notification();
+        $notificationClass = $container->getParameter('mgilet_notification.notification_class');
+        $notification = new $notificationClass();
         $notification
             ->setSubject($subject)
             ->setMessage($message)

--- a/MgiletNotificationBundle.php
+++ b/MgiletNotificationBundle.php
@@ -2,7 +2,9 @@
 
 namespace Mgilet\NotificationBundle;
 
+use Mgilet\NotificationBundle\DependencyInjection\Compiler\ResolveTargetEntitiesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * MgiletNotificationBundle
@@ -15,4 +17,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class MgiletNotificationBundle extends Bundle
 {
+    public function build(ContainerBuilder $container){
+        parent::build($container);
+        $container->addCompilerPass(new ResolveTargetEntitiesPass());
+    }
 }

--- a/MgiletNotificationBundle.php
+++ b/MgiletNotificationBundle.php
@@ -5,6 +5,7 @@ namespace Mgilet\NotificationBundle;
 use Mgilet\NotificationBundle\DependencyInjection\Compiler\ResolveTargetEntitiesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
 /**
  * MgiletNotificationBundle
@@ -19,6 +20,6 @@ class MgiletNotificationBundle extends Bundle
 {
     public function build(ContainerBuilder $container){
         parent::build($container);
-        $container->addCompilerPass(new ResolveTargetEntitiesPass());
+        $container->addCompilerPass(new ResolveTargetEntitiesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 }


### PR DESCRIPTION
This PR is about issue #39

I've found that if the default Notification entity is overridden, the `NotificationManager::createNotification` method still returns a `Mgilet\NotificationBundle\Entity\Notification ` object and it throws an exception when flushing to the db due to `resolve_target_entities` directive configured in doctrine orm.

### What i have done

1. Added a configuration to the bundle where to specify the customized notification class;
2. Added a compiler pass named `ResolveTargetEntitiesPass` that adds the `resolve_target_entities` without explicitly changing doctrine configuration;
3. Changed the manager that now  returns the customized notification class;
4. Changed the ordering default field from id to date. 

Point no. 4 was added due to the possibility to customize the notification entity. To me it was necessary to change the notification ID from int autoincrement to UUID so the sort didn't work.

### BC breaks

Accepting this PR means that who already uses a customized notification class must remove the `resolve_target_entities` directive from the doctrine configuration and add a configuration file.

### Example
After adding the customized notification class as in #39 just add a configuration file

**config/packages/mgilet_notification.yaml**
```
mgilet_notification:
  notification_class: App\Entity\MyCustomNotification
```
Can it be useful?
