### PR TITLE
Adding removeNotificationAction to NotificationController

### DIFF
--- a/Controller/NotificationController.php
+++ b/Controller/NotificationController.php
@@ -113,4 +113,29 @@ class NotificationController extends Controller
 
         return new JsonResponse(true);
     }
+
+    /**
+     * Remove a notification for a NotifiableEntity
+     *
+     * @Route("/{notifiable}/remove_notification/{notification}", name="notification_remove")
+     * @Method("POST")
+     * @param $notifiable
+     * @param $notification
+     *
+     * @return JsonResponse
+     * @throws \Doctrine\ORM\ORMInvalidArgumentException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    public function removeNotificationAction($notifiable, $notification)
+    {
+
+        $manager = $this->get('mgilet.notification');
+
+        $manager->removeNotification( [$manager->getNotifiableInterface($manager->getNotifiableEntityById($notifiable))],
+            $manager->getNotification($notification));
+        return new JsonResponse(true);
+    }
+
 }

--- a/Entity/NotifiableNotification.php
+++ b/Entity/NotifiableNotification.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @package Mgilet\NotificationBundle\Entity
  *
  * @ORM\Entity(repositoryClass="Mgilet\NotificationBundle\Entity\Repository\NotifiableNotificationRepository")
+ * @ORM\Table(uniqueConstraints={@ORM\UniqueConstraint(name="notified_unique",columns={"notifiable_entity_id", "notification_id"})})
  *
  */
 class NotifiableNotification implements \JsonSerializable

--- a/Entity/NotifiableNotification.php
+++ b/Entity/NotifiableNotification.php
@@ -31,6 +31,7 @@ class NotifiableNotification implements \JsonSerializable
     /**
      * @var Notification
      * @ORM\ManyToOne(targetEntity="Mgilet\NotificationBundle\Entity\Notification", inversedBy="notifiableNotifications", cascade={"persist"})
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     protected $notification;
 

--- a/Manager/NotificationManager.php
+++ b/Manager/NotificationManager.php
@@ -353,6 +353,7 @@ class NotificationManager
      * @throws \Doctrine\ORM\ORMInvalidArgumentException
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
+     * @throws \Doctrine\DBAL\Exception\UniqueConstraintViolationException
      */
     public function addNotification($notifiables, NotificationInterface $notification, $flush = false)
     {

--- a/Manager/NotificationManager.php
+++ b/Manager/NotificationManager.php
@@ -376,16 +376,16 @@ class NotificationManager
      *
      * @param array                 $notifiables
      * @param NotificationInterface $notification
-     * @param bool                  $flush
      *
      * @throws \Doctrine\ORM\ORMInvalidArgumentException
      * @throws \Doctrine\ORM\OptimisticLockException
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public function removeNotification(array $notifiables, NotificationInterface $notification, $flush = false)
+    public function removeNotification(array $notifiables, NotificationInterface $notification)
     {
         $repo = $this->om->getRepository('MgiletNotificationBundle:NotifiableNotification');
+
         foreach ($notifiables as $notifiable) {
             $repo->createQueryBuilder('nn')
                 ->delete()
@@ -400,7 +400,19 @@ class NotificationManager
             $this->dispatcher->dispatch(MgiletNotificationEvents::REMOVED, $event);
         }
 
-        $this->flush($flush);
+        // Counts the Notifiable that still links the Notifications
+        $notifiableNumbers = $repo->createQueryBuilder('nn')
+            ->select('COUNT(nn.notification)')
+            ->where('nn.notification = :notification')
+            ->groupBy('nn.notification')
+            ->setParameter('notification', $notification)
+            ->getQuery()->execute();
+        // If there's no Notifiable linked to the Notification
+        // then deletes it
+        if(empty($notifiableNumbers))
+        {
+            $this->deleteNotification($notification, true);
+        }
     }
 
     /**

--- a/Twig/NotificationExtension.php
+++ b/Twig/NotificationExtension.php
@@ -202,6 +202,19 @@ class NotificationExtension extends Twig_Extension
             case 'notification_mark_all_as_seen':
                 return $this->router->generate('notification_mark_all_as_seen', array('notifiable' => $notifiableId));
                 break;
+            case 'notification_remove':
+                if (!$notification) {
+                    throw new \InvalidArgumentException('You must provide a Notification Entity');
+                }
+
+                return $this->router->generate(
+                    'notification_remove',
+                    array(
+                        'notifiable' => $notifiableId,
+                        'notification' => $notification->getId()
+                    )
+                );
+                break;
             default:
                 return new \InvalidArgumentException('You must provide a valid route path. Paths availables : notification_list, notification_mark_as_seen, notification_mark_as_unseen, notification_mark_all_as_seen');
         }


### PR DESCRIPTION
This PR is about removing Notifications from Notifiable point of view.

Let's think about a User (that is a `Notifiable`) point of view. It can be able to delete his own notifications.

### What i have done

As you can see in commits descriptions

1. Added a database level "_ON DELETE CASCADE_" behaviour to NotifibiableNotification. This means that if a notification is deleted all the links between it and a Notifiable are deleted too. It was realized by ON DELETE and not by doctrine persist clause just for performances.
2. Added `NotificationController#removeNotificationAction `to handle deletion of a NotifiableNotification. Added also the generation of "notification_remove" route into Twig\NotificationExtension
3. Added UniqueConstraint to NotifiableNotification on columns notifiable_entity_id and notification_id to assure no duplicates of the same notification for a Notifiable
4. Updated `NotificationManager#removeNotification`, now removes also Notification without any link in NotifiableNotification to keep the database clean. I've also removed the flush parameter as no flush is requested to execute the query.

### BC breaks
Accepting this PR means update the database schema by `php bin\console doctrine:schema:update --dump-sql --force` and remove `$flush` parameter when using `NotificationManager#removeNotification`

Let me know what you think.
Thanks

 

