### PR TITLE
Replace TokenStorage with TokenStorageInterface

### DIFF
--- a/Twig/NotificationExtension.php
+++ b/Twig/NotificationExtension.php
@@ -8,7 +8,7 @@ use Mgilet\NotificationBundle\Entity\NotificationInterface;
 use Mgilet\NotificationBundle\Manager\NotificationManager;
 use Mgilet\NotificationBundle\NotifiableInterface;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Twig_Extension;
 
 /**
@@ -28,7 +28,7 @@ class NotificationExtension extends Twig_Extension
      * @param \Twig_Environment $twig
      * @param RouterInterface $router
      */
-    public function __construct(NotificationManager $notificationManager, TokenStorage $storage, \Twig_Environment $twig, RouterInterface $router)
+    public function __construct(NotificationManager $notificationManager, TokenStorageInterface $storage, \Twig_Environment $twig, RouterInterface $router)
     {
         $this->notificationManager = $notificationManager;
         $this->storage = $storage;


### PR DESCRIPTION
After upgrade to symfony 4.4 I had this error:

```
TypeError:
Argument 2 passed to Mgilet\NotificationBundle\Twig\NotificationExtension::__construct() must be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage, instance of Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage given, called in /var/www//var/cache/dev/ContainerBoWRTqH/srcApp_KernelDevDebugContainer.php on line 1396

  at vendor/mgilet/notification-bundle/Twig/NotificationExtension.php:30
  at Mgilet\NotificationBundle\Twig\NotificationExtension->__construct(object(NotificationManager), object(UsageTrackingTokenStorage), object(Environment), object(Router))
     (var/cache/dev/ContainerBoWRTqH/srcApp_KernelDevDebugContainer.php:1396)
  at ContainerBoWRTqH\srcApp_KernelDevDebugContainer->getTwigService()
     (var/cache/dev/ContainerBoWRTqH/srcApp_KernelDevDebugContainer.php:2156)
  at ContainerBoWRTqH\srcApp_KernelDevDebugContainer->getSensioFrameworkExtra_View_ListenerService()
     (var/cache/dev/ContainerBoWRTqH/srcApp_KernelDevDebugContainer.php:1044)
  at ContainerBoWRTqH\srcApp_KernelDevDebugContainer->ContainerBoWRTqH\{closure}()
     (vendor/symfony/event-dispatcher/EventDispatcher.php:279)
  at Symfony\Component\EventDispatcher\EventDispatcher->sortListeners('kernel.controller')
     (vendor/symfony/event-dispatcher/EventDispatcher.php:90)
  at Symfony\Component\EventDispatcher\EventDispatcher->getListeners('kernel.controller')
     (vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:334)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->preProcess('kernel.controller')
     (vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:162)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(object(ControllerEvent), 'kernel.controller')
     (vendor/symfony/http-kernel/HttpKernel.php:134)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:25)
```