### PR TITLE
Re-enable rendering HTML in notification list

### DIFF
--- a/Twig/NotificationExtension.php
+++ b/Twig/NotificationExtension.php
@@ -44,10 +44,10 @@ class NotificationExtension extends AbstractExtension
     public function getFunctions()
     {
         return array(
-            new TwigFunction('mgilet_notification_render', [$this, 'render']),
-            new TwigFunction('mgilet_notification_count', [$this, 'countNotifications']),
-            new TwigFunction('mgilet_notification_unseen_count', [$this, 'countUnseenNotifications']),
-            new TwigFunction('mgilet_notification_generate_path', [$this, 'generatePath'])
+            new TwigFunction('mgilet_notification_render', [$this, 'render'], ['is_safe' => ['html']]),
+            new TwigFunction('mgilet_notification_count', [$this, 'countNotifications'], ['is_safe' => ['html']]),
+            new TwigFunction('mgilet_notification_unseen_count', [$this, 'countUnseenNotifications'], ['is_safe' => ['html']]),
+            new TwigFunction('mgilet_notification_generate_path', [$this, 'generatePath'], ['is_safe' => ['html']])
         );
     }
 


### PR DESCRIPTION
In the 3.1 release, it was possible to render HTML in the template
passed to `mgilet_notification_render()`. Since 3.2, this isn't possible
any more and instead, all HTML is escaped. This change of behavior was
introduced in https://github.com/maximilienGilet/notification-bundle/pull/71.
Unfortunately, the PR and commit message are very short on detail,
making it hard to judge if this change was intentional or not. Either
way, it breaks compatibility with existing code and shouldn't be
introduced in a minor release.

This patch changes the behavior back to the 3.1-like behavior.

Specific code that broke by the 3.2 update:

* https://github.com/librecores/librecores-web/blob/451c69cd1693ef8ceafb84cb3c7690be1cd9557d/site/app/Resources/views/base.html.twig#L68
* Template: https://github.com/librecores/librecores-web/blob/master/site/app/Resources/views/notification/notification_list.html.twig