### PR TITLE
Fix obsolete \Twig_Environment class

### DIFF
--- a/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
+++ b/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
@@ -11,7 +11,6 @@ namespace Mgilet\NotificationBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Mgilet\NotificationBundle\Entity\NotificationInterface;
-use Symfony\Component\Debug\Exception\ClassNotFoundException;
 use Doctrine\ORM\Version;
 
 class ResolveTargetEntitiesPass implements CompilerPassInterface
@@ -30,7 +29,7 @@ class ResolveTargetEntitiesPass implements CompilerPassInterface
         }
         // Throws exception if the class isn't found
         if (!class_exists($notificationEntityClass)) {
-            throw new ClassNotFoundException(sprintf("Can't find class %s ", $notificationEntityClass));
+            throw new \ErrorException(sprintf("Can't find class %s ", $notificationEntityClass));
         }
 
         // Get the doctrine ResolveTargetEntityListener

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -14,6 +14,10 @@ use Mgilet\NotificationBundle\Entity\NotificationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * {@inheritdoc}
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('mgilet_notification');

--- a/Entity/NotifiableEntity.php
+++ b/Entity/NotifiableEntity.php
@@ -145,6 +145,7 @@ class NotifiableEntity implements \JsonSerializable
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function jsonSerialize()
     {

--- a/Entity/NotifiableNotification.php
+++ b/Entity/NotifiableNotification.php
@@ -118,6 +118,7 @@ class NotifiableNotification implements \JsonSerializable
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function jsonSerialize()
     {

--- a/Event/NotificationEvent.php
+++ b/Event/NotificationEvent.php
@@ -4,7 +4,7 @@ namespace Mgilet\NotificationBundle\Event;
 
 use Mgilet\NotificationBundle\Entity\NotificationInterface;
 use Mgilet\NotificationBundle\NotifiableInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class NotificationEvent extends Event
 {

--- a/Manager/NotificationManager.php
+++ b/Manager/NotificationManager.php
@@ -338,7 +338,7 @@ class NotificationManager
             ->setLink($link);
 
         $event = new NotificationEvent($notification);
-        $this->dispatcher->dispatch(MgiletNotificationEvents::CREATED, $event);
+        $this->dispatcher->dispatch($event, MgiletNotificationEvents::CREATED);
 
         return $notification;
     }
@@ -365,7 +365,7 @@ class NotificationManager
             $notification->addNotifiableNotification($notifiableNotification);
 
             $event = new NotificationEvent($notification, $notifiable);
-            $this->dispatcher->dispatch(MgiletNotificationEvents::ASSIGNED, $event);
+            $this->dispatcher->dispatch($event, MgiletNotificationEvents::ASSIGNED);
         }
 
         $this->flush($flush);
@@ -397,7 +397,7 @@ class NotificationManager
                 ->execute();
 
             $event = new NotificationEvent($notification, $notifiable);
-            $this->dispatcher->dispatch(MgiletNotificationEvents::REMOVED, $event);
+            $this->dispatcher->dispatch($event, MgiletNotificationEvents::REMOVED);
             $this->flush($flush);
         }
 
@@ -419,7 +419,7 @@ class NotificationManager
         $this->flush($flush);
 
         $event = new NotificationEvent($notification);
-        $this->dispatcher->dispatch(MgiletNotificationEvents::DELETED, $event);
+        $this->dispatcher->dispatch($event, MgiletNotificationEvents::DELETED);
     }
 
     /**
@@ -437,7 +437,7 @@ class NotificationManager
         if ($nn) {
             $nn->setSeen(true);
             $event = new NotificationEvent($notification, $notifiable);
-            $this->dispatcher->dispatch(MgiletNotificationEvents::SEEN, $event);
+            $this->dispatcher->dispatch($event, MgiletNotificationEvents::SEEN);
             $this->flush($flush);
         } else {
             throw new EntityNotFoundException('The link between the notifiable and the notification has not been found');
@@ -459,7 +459,7 @@ class NotificationManager
         if ($nn) {
             $nn->setSeen(false);
             $event = new NotificationEvent($notification, $notifiable);
-            $this->dispatcher->dispatch(MgiletNotificationEvents::UNSEEN, $event);
+            $this->dispatcher->dispatch($event, MgiletNotificationEvents::UNSEEN);
             $this->flush($flush);
         } else {
             throw new EntityNotFoundException('The link between the notifiable and the notification has not been found');
@@ -483,7 +483,7 @@ class NotificationManager
         foreach ($nns as $nn) {
             $nn->setSeen(true);
             $event = new NotificationEvent($nn->getNotification(), $notifiable);
-            $this->dispatcher->dispatch(MgiletNotificationEvents::SEEN, $event);
+            $this->dispatcher->dispatch($event, MgiletNotificationEvents::SEEN);
         }
         $this->flush($flush);
     }
@@ -575,7 +575,7 @@ class NotificationManager
         $this->flush($flush);
 
         $event = new NotificationEvent($notification);
-        $this->dispatcher->dispatch(MgiletNotificationEvents::MODIFIED, $event);
+        $this->dispatcher->dispatch($event, MgiletNotificationEvents::MODIFIED);
 
         return $notification;
     }
@@ -594,7 +594,7 @@ class NotificationManager
         $this->flush($flush);
 
         $event = new NotificationEvent($notification);
-        $this->dispatcher->dispatch(MgiletNotificationEvents::MODIFIED, $event);
+        $this->dispatcher->dispatch($event, MgiletNotificationEvents::MODIFIED);
 
         return $notification;
     }
@@ -613,7 +613,7 @@ class NotificationManager
         $this->flush($flush);
 
         $event = new NotificationEvent($notification);
-        $this->dispatcher->dispatch(MgiletNotificationEvents::MODIFIED, $event);
+        $this->dispatcher->dispatch($event, MgiletNotificationEvents::MODIFIED);
 
         return $notification;
     }
@@ -632,7 +632,7 @@ class NotificationManager
         $this->flush($flush);
 
         $event = new NotificationEvent($notification);
-        $this->dispatcher->dispatch(MgiletNotificationEvents::MODIFIED, $event);
+        $this->dispatcher->dispatch($event, MgiletNotificationEvents::MODIFIED);
 
         return $notification;
     }

--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -197,6 +197,7 @@ abstract class Notification implements \JsonSerializable
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function jsonSerialize()
     {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,3 +15,7 @@ services:
             public: false
             tags:
                 - { name: twig.extension }
+
+    Mgilet\NotificationBundle\Controller\NotificationController:
+        calls:
+            - [ setContainer, [ '@service_container' ] ]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -17,5 +17,6 @@ services:
                 - { name: twig.extension }
 
     Mgilet\NotificationBundle\Controller\NotificationController:
+        autoconfigure: true
         calls:
             - [ setContainer, [ '@service_container' ] ]

--- a/Twig/NotificationExtension.php
+++ b/Twig/NotificationExtension.php
@@ -9,9 +9,9 @@ use Mgilet\NotificationBundle\Manager\NotificationManager;
 use Mgilet\NotificationBundle\NotifiableInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-//use Twig_Extension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use Twig\Environment as TwigEnvironment;
 
 /**
  * Twig extension to display notifications
@@ -27,10 +27,10 @@ class NotificationExtension extends AbstractExtension
      * NotificationExtension constructor.
      * @param NotificationManager $notificationManager
      * @param TokenStorage $storage
-     * @param \Twig_Environment $twig
+     * @param TwigEnvironment $twig
      * @param RouterInterface $router
      */
-    public function __construct(NotificationManager $notificationManager, TokenStorageInterface $storage, \Twig_Environment $twig, RouterInterface $router)
+    public function __construct(NotificationManager $notificationManager, TokenStorageInterface $storage, TwigEnvironment $twig, RouterInterface $router)
     {
         $this->notificationManager = $notificationManager;
         $this->storage = $storage;

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require" : {
     "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-    "twig/twig": "*",
+    "twig/twig": "^2.12|^3.0",
     "doctrine/doctrine-bundle": "*"
   },
   "autoload" : {


### PR DESCRIPTION
The fix of obsolete \Twig_Environment class, replaced with Twig\Environment namespace.
This is tested on Symfony 4.4 LTS, composer.json got "twig/twig" require version same as in symfony.
The project with very old twig 1.* will not work with this fix.